### PR TITLE
Copy the templates to the application if they don't exist there

### DIFF
--- a/commands/wheels/generate/controller.cfc
+++ b/commands/wheels/generate/controller.cfc
@@ -54,13 +54,10 @@ component
       }
       actionContent = allactions;
     } else {
+      //Copy template files to the application folder if they do not exist there
+      ensureSnippetTemplatesExist();
       // Do Crud: overrwrite whole controllerContent with CRUD template
-      if(fileExists(fileSystemUtil.resolvePath('app/snippets/CRUDContent.txt'))){
-				controllerContent 	= fileRead(fileSystemUtil.resolvePath('app/snippets/CRUDContent.txt'));
-			}
-			else{
-        controllerContent = fileRead( getTemplate( '/CRUDContent.txt' ) );
-			}
+      controllerContent = fileRead(fileSystemUtil.resolvePath('app/snippets/CRUDContent.txt'));
       print.yellowLine( 'Generating CRUD' );
     }
 

--- a/commands/wheels/generate/model.cfc
+++ b/commands/wheels/generate/model.cfc
@@ -29,6 +29,8 @@ component aliases='wheels g model' extends="../base"  {
 		//TODO: Refactor into a function that tries to get the app name from the server.json file
 		var appName				= listLast( getCWD(), '/\' );
 
+		//Copy template files to the application folder if they do not exist there 
+		ensureSnippetTemplatesExist();
 		if(db){
 			print.line( "Trying to Generate DB Tables").toConsole();
 			command('wheels dbmigrate create table #obj.objectNamePlural#').run();
@@ -44,12 +46,7 @@ component aliases='wheels g model' extends="../base"  {
  		}
 
  		// Read in Template
-		if(fileExists(fileSystemUtil.resolvePath('app/snippets/ModelContent.txt'))){
-			var modelContent 	= fileRead(fileSystemUtil.resolvePath('app/snippets/ModelContent.txt'));
-		}
-		else{
-			var modelContent 	= fileRead( getTemplate('/ModelContent.txt'));
-		}
+		var modelContent = fileRead(fileSystemUtil.resolvePath('app/snippets/ModelContent.txt'));
 		var modelName = obj.objectNameSingularC & ".cfc";
 		var modelPath = directory & "/" & modelName;
 

--- a/commands/wheels/generate/test.cfc
+++ b/commands/wheels/generate/test.cfc
@@ -70,13 +70,10 @@ component aliases='wheels g test' extends="../base"  {
 			error( "[#testPath#] already exists?" );
  		}
 
+		//Copy template files to the application folder if they do not exist there
+		ensureSnippetTemplatesExist();
 		// Get test content
-		if(fileExists(fileSystemUtil.resolvePath('app/snippets/tests/#type#.txt'))){
-			var testContent= fileRead(fileSystemUtil.resolvePath('app/snippets/tests/#type#.txt'));
-		}
-		else{
-			var testContent= fileRead(getTemplate("tests/#type#.txt"));
-		}
+		var testContent = fileRead(fileSystemUtil.resolvePath('app/snippets/tests/#type#.txt'));
 		file action='write' file='#testPath#' mode ='777' output='#trim( testContent )#';
 		print.line( 'Created Test Stub #testPath#' );
 	}

--- a/commands/wheels/generate/view.cfc
+++ b/commands/wheels/generate/view.cfc
@@ -43,22 +43,14 @@ component aliases='wheels g view' extends="../base"  {
  			print.line( "#directory# created" ).toConsole();
  		}
 
+		//Copy template files to the application folder if they do not exist there
+		ensureSnippetTemplatesExist();
  		// Read in Template
 		var viewContent 	= "";
  		if(!len(arguments.template)){
-			if(fileExists(fileSystemUtil.resolvePath('app/snippets/viewContent.txt'))){
-				viewContent 	= fileRead(fileSystemUtil.resolvePath('app/snippets/viewContent.txt'));
-			}
-			else{
-				viewContent 	= fileRead( getTemplate( '/viewContent.txt'));
-			}
+			viewContent = fileRead(fileSystemUtil.resolvePath('app/snippets/viewContent.txt'));
 		} else {
-			if(fileExists(fileSystemUtil.resolvePath('app/snippets/' & arguments.template & '.txt'))){
-				viewContent 	= fileRead(fileSystemUtil.resolvePath('app/snippets/' & arguments.template & '.txt'));
-			}
-			else{
-				viewContent 	= fileRead( getTemplate( arguments.template & '.txt'));
-			}
+			viewContent = fileRead(fileSystemUtil.resolvePath('app/snippets/' & arguments.template & '.txt'));
 		}
 		// Replace Object tokens
 		viewContent=$replaceDefaultObjectNames(viewContent, obj);


### PR DESCRIPTION
Added `ensureSnippetTemplatesExist` function to check for and create the `app/snippets` directory if it doesn't exist. It also verifies each required file and copies it only if it's missing.

Called this function in the model, controller, view, and test files.

Removed the `directoryCopy` call from `getTemplateDirectory` to avoid copying unnecessary folders like `bootstrap`.