### PR TITLE
Command Introduce for snippets to always available

### DIFF
--- a/commands/wheels/generate/snippets.cfc
+++ b/commands/wheels/generate/snippets.cfc
@@ -1,0 +1,25 @@
+/**
+ * Copies the template snippets to the application.
+ */
+component
+  aliases="wheels g snippets"
+  extends="../base"
+{
+
+  function run() 
+  {
+    arguments.directory = fileSystemUtil.resolvePath( 'app' );
+
+    print.line('Starting snippet generation...').toConsole();
+
+    // Validate the provided directory
+    if (!directoryExists(arguments.directory)) {
+      error('[#arguments.directory#] can''t be found. Are you running this command from your application root?');
+    }
+
+    ensureSnippetTemplatesExist();
+
+    print.line('Snippet successfully generated in the /app/snippets folder.');
+  }
+
+}


### PR DESCRIPTION
Removed the Fallback template path for the template generation and updated the error message to tell the user to run the "wheels g snippets" command to generate templates in the application.