### PR TITLE
Rename CFWheels to Wheels throughout the codebase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,10 +20,10 @@
 * Fixes Encode Attributes as bootstrap template default to form helpers [Tom King]
 
 0.2.4
-* Various scaffolding syntax updates for CFWheels 2.0
+* Various scaffolding syntax updates for Wheels 2.0
 
 0.2.2
-* Adds CFWheels 2.0
+* Adds Wheels 2.0
 
 0.1.6
 * Add travis Adapter Test
@@ -47,7 +47,7 @@ Enhancements
 * CLI can identify Wheels version from box.json #16
 * `wheels reload` (alias `r`) command added #20
 * `wheels new` now offers and configures a H2 database for development when on lucee #19
-* `wheels init` allows for existing CFWheels apps to be prepped for CLI usage #21
+* `wheels init` allows for existing Wheels apps to be prepped for CLI usage #21
 
 Bug Fixes
 =================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
-This is the CFWheels CLI, a CommandBox module that provides command-line tools for CFWheels framework applications.
+This is the Wheels CLI, a CommandBox module that provides command-line tools for Wheels framework applications.
 
 ## Commands
 - **Test**: `wheels test [type] [servername] [reload] [debug]`
@@ -22,7 +22,7 @@ This is the CFWheels CLI, a CommandBox module that provides command-line tools f
 - **Code Generation**: Follow existing template patterns when modifying or creating new templates
 
 ## Development Notes
-- This is a CommandBox module that integrates with CFWheels framework
+- This is a CommandBox module that integrates with Wheels framework
 - Follow MVC pattern when creating new features
 - Maintain backward compatibility when possible
 - Refer to CLI-IMPROVEMENTS.md for planned enhancements and architectural goals

--- a/CLI-IMPROVEMENTS-README.md
+++ b/CLI-IMPROVEMENTS-README.md
@@ -1,8 +1,8 @@
-# CFWheels CLI Improvements - Rationale
+# Wheels CLI Improvements - Rationale
 
 ## Background
 
-The current CFWheels CLI tool provides essential commands for creating and managing CFWheels applications. However, as modern web development practices evolve, there are opportunities to enhance the CLI to improve developer productivity, code quality, and application performance.
+The current Wheels CLI tool provides essential commands for creating and managing Wheels applications. However, as modern web development practices evolve, there are opportunities to enhance the CLI to improve developer productivity, code quality, and application performance.
 
 ## Why These Improvements Matter
 
@@ -16,7 +16,7 @@ The web development landscape has shifted toward API-centric applications and mo
 
 ### DevOps Integration
 
-As deployment processes become more automated, the proposed CI/CD and Docker integrations help CFWheels developers adopt modern DevOps practices, ensuring consistent builds, deployments, and environments.
+As deployment processes become more automated, the proposed CI/CD and Docker integrations help Wheels developers adopt modern DevOps practices, ensuring consistent builds, deployments, and environments.
 
 ### Performance Optimization
 
@@ -33,12 +33,12 @@ The proposed improvements are designed to be:
 
 ## Community Benefits
 
-These improvements will benefit the CFWheels community by:
+These improvements will benefit the Wheels community by:
 
-1. Making CFWheels more attractive to new developers
+1. Making Wheels more attractive to new developers
 2. Providing existing developers with modern tools to improve their workflow
 3. Reducing the friction when adopting best practices
-4. Encouraging standardization across CFWheels applications
+4. Encouraging standardization across Wheels applications
 
 ## Next Steps
 

--- a/CLI-IMPROVEMENTS.md
+++ b/CLI-IMPROVEMENTS.md
@@ -1,6 +1,6 @@
-# CFWheels CLI Improvements
+# Wheels CLI Improvements
 
-This document outlines proposed improvements to the CFWheels CLI tool (wheels-cli CommandBox module).
+This document outlines proposed improvements to the Wheels CLI tool (wheels-cli CommandBox module).
 
 ## 1. Interactive Development Mode
 
@@ -42,7 +42,7 @@ This document outlines proposed improvements to the CFWheels CLI tool (wheels-cl
 
 **New Command:** `wheels generate frontend [framework]`
 
-**Description:** Scaffold and integrate modern frontend frameworks with CFWheels.
+**Description:** Scaffold and integrate modern frontend frameworks with Wheels.
 
 **Implementation:**
 - Support popular frameworks like React, Vue, Alpine.js
@@ -67,10 +67,10 @@ This document outlines proposed improvements to the CFWheels CLI tool (wheels-cl
 
 **New Command:** `wheels deps [action]`
 
-**Description:** Manage CFWheels-specific dependencies and plugins with version control.
+**Description:** Manage Wheels-specific dependencies and plugins with version control.
 
 **Implementation:**
-- Add commands to install, update, and remove CFWheels plugins
+- Add commands to install, update, and remove Wheels plugins
 - Create dependency tracking and resolution
 - Include compatibility checking between components
 - Generate dependency reports
@@ -131,4 +131,4 @@ This document outlines proposed improvements to the CFWheels CLI tool (wheels-cl
 4. Include tests for all new functionality
 5. Submit pull requests to the main wheels-cli repository
 
-These improvements will significantly enhance the developer experience when working with CFWheels applications, bringing modern workflow practices to the framework.
+These improvements will significantly enhance the developer experience when working with Wheels applications, bringing modern workflow practices to the framework.

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -15,12 +15,12 @@ component {
 
     // Runs when module is loaded
     function onLoad(){
-        log.info('CFWheels Module loaded successfully.' );
+        log.info('Wheels Module loaded successfully.' );
     }
 
     // Runs when module is unloaded
     function onUnLoad(){
-        log.info('CFWheels Module unloaded successfully.' );
+        log.info('Wheels Module unloaded successfully.' );
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Skips things like `rails server` which are provided by CommandBox already.
 Simply run `install wheels-cli` from CommandBox to install the latest release.
 
 ## Commands
-See [the CLI command guides](https://guides.cfwheels.org/cfwheels-guides/3.0.0-snapshot/command-line-tools/cli-commands) or use `help wheels` in Commandbox.
+See [the CLI command guides](https://guides.wheels.dev/wheels-guides/3.0.0-snapshot/command-line-tools/cli-commands) or use `help wheels` in Commandbox.

--- a/commands/wheels/analyze.cfc
+++ b/commands/wheels/analyze.cfc
@@ -25,7 +25,7 @@ component extends="base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Performance Analyzer");
+        print.boldMagentaLine("Wheels Performance Analyzer");
         print.line();
         
         // Validate target

--- a/commands/wheels/base.cfc
+++ b/commands/wheels/base.cfc
@@ -36,7 +36,7 @@ component excludeFromHelp=true {
 			print.line("We're currently looking in #getCWD()#");
 			if(confirm("Would you like to try and create one? [y/n]")){
 				local.version=ask("Which Version is it? Please enter your response in semVar format, i.e '1.4.5'");
-				command('init').params(name="CFWHEELS", version=local.version, slugname="cfwheels").run();
+				command('init').params(name="CFWHEELS", version=local.version, slugname="wheels").run();
 				return local.version;
 			} else {
 				error("Ok, aborting");
@@ -208,13 +208,13 @@ component excludeFromHelp=true {
 			 // Wheels folder in expected place? (just a good check to see if the user has actually installed wheels...)
  		var wheelsFolder=fileSystemUtil.resolvePath("vendor/wheels");
  			if(!directoryExists(wheelsFolder)){
- 				error("We can't find your wheels folder. Check you have installed CFWheels, and you're running this from the site root: If you've not started an app yet, try wheels new myApp");
+ 				error("We can't find your wheels folder. Check you have installed Wheels, and you're running this from the site root: If you've not started an app yet, try wheels new myApp");
  			}
 
 			 // Plugins in place?
  		var pluginsFolder=fileSystemUtil.resolvePath("plugins");
  			if(!directoryExists(wheelsFolder)){
- 				error("We can't find your plugins folder. Check you have installed CFWheels, and you're running this from the site root.");
+ 				error("We can't find your plugins folder. Check you have installed Wheels, and you're running this from the site root.");
  			}
 
 			 // Wheels 1.x requires dbmigrate plugin

--- a/commands/wheels/ci/init.cfc
+++ b/commands/wheels/ci/init.cfc
@@ -21,7 +21,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels CI/CD Configuration Generator");
+        print.boldMagentaLine("Wheels CI/CD Configuration Generator");
         print.line();
         
         // Validate platform selection
@@ -64,7 +64,7 @@ component extends="../base" {
         // Create CI workflow
         local.ciWorkflowPath = local.workflowsDir & "/ci.yml";
         
-        local.ciWorkflowContent = "name: CFWheels CI
+        local.ciWorkflowContent = "name: Wheels CI
 
 on:
   push:
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         run: box install
         
-      - name: Set up CFWheels
+      - name: Set up Wheels
         run: |
           box server start
           box wheels reload
@@ -128,7 +128,7 @@ jobs:
         if (arguments.includeDeployment) {
             local.deployWorkflowPath = local.workflowsDir & "/deploy.yml";
             
-            local.deployWorkflowContent = "name: CFWheels Deploy
+            local.deployWorkflowContent = "name: Wheels Deploy
 
 on:
   push:

--- a/commands/wheels/config/env.cfc
+++ b/commands/wheels/config/env.cfc
@@ -21,7 +21,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Environment Manager");
+        print.boldMagentaLine("Wheels Environment Manager");
         print.line();
         
         // Handle different actions

--- a/commands/wheels/config/list.cfc
+++ b/commands/wheels/config/list.cfc
@@ -21,7 +21,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Configuration Settings");
+        print.boldMagentaLine("Wheels Configuration Settings");
         print.line();
         
         // Create URL parameters

--- a/commands/wheels/config/set.cfc
+++ b/commands/wheels/config/set.cfc
@@ -20,7 +20,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Configuration Manager");
+        print.boldMagentaLine("Wheels Configuration Manager");
         print.line();
         
         // Parse the key-value pair

--- a/commands/wheels/db/schema.cfc
+++ b/commands/wheels/db/schema.cfc
@@ -21,7 +21,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Database Schema");
+        print.boldMagentaLine("Wheels Database Schema");
         print.line();
         
         // Validate format

--- a/commands/wheels/db/seed.cfc
+++ b/commands/wheels/db/seed.cfc
@@ -23,7 +23,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Database Seed");
+        print.boldMagentaLine("Wheels Database Seed");
         print.line();
         
         // Create URL parameters

--- a/commands/wheels/deps.cfc
+++ b/commands/wheels/deps.cfc
@@ -1,5 +1,5 @@
 /**
- * Manage CFWheels-specific dependencies and plugins
+ * Manage Wheels-specific dependencies and plugins
  * 
  * {code:bash}
  * wheels deps list
@@ -23,7 +23,7 @@ component extends="base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Dependency Manager");
+        print.boldMagentaLine("Wheels Dependency Manager");
         print.line();
         
         // Validate action

--- a/commands/wheels/docker/deploy.cfc
+++ b/commands/wheels/docker/deploy.cfc
@@ -23,7 +23,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Docker Production Deployment");
+        print.boldMagentaLine("Wheels Docker Production Deployment");
         print.line();
         
         // Validate inputs
@@ -377,18 +377,18 @@ TZ=UTC
         local.deployPath = fileSystemUtil.resolvePath("deploy.sh");
         
         local.deployContent = "#!/bin/bash
-# Deployment script for CFWheels Docker
+# Deployment script for Wheels Docker
 
 # Usage: ./deploy.sh [environment]
 ENV=\${1:-production}
 
-echo \"Deploying CFWheels to \$ENV environment...\"
+echo \"Deploying Wheels to \$ENV environment...\"
 
 # Build and start the containers
 docker-compose -f docker-compose.\$ENV.yml build --no-cache
 docker-compose -f docker-compose.\$ENV.yml up -d
 
-echo \"CFWheels deployed to \$ENV environment!\"
+echo \"Wheels deployed to \$ENV environment!\"
 ";
         
         file action='write' file='#local.deployPath#' mode='777' output='#local.deployContent#';

--- a/commands/wheels/docker/init.cfc
+++ b/commands/wheels/docker/init.cfc
@@ -23,7 +23,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Docker Configuration");
+        print.boldMagentaLine("Wheels Docker Configuration");
         print.line();
         
         // Validate inputs
@@ -226,7 +226,7 @@ CMD ["/opt/coldfusion/bin/coldfusion", "start"]";
     private void function createMySqlInit(required string path) {
         local.initSqlPath = arguments.path & "/init.sql";
         
-        local.initSqlContent = "-- MySQL initialization script for CFWheels Docker setup
+        local.initSqlContent = "-- MySQL initialization script for Wheels Docker setup
 CREATE DATABASE IF NOT EXISTS cfwheels;
 USE cfwheels;
 
@@ -248,7 +248,7 @@ FLUSH PRIVILEGES;
     private void function createPostgresInit(required string path) {
         local.initSqlPath = arguments.path & "/init.sql";
         
-        local.initSqlContent = "-- PostgreSQL initialization script for CFWheels Docker setup
+        local.initSqlContent = "-- PostgreSQL initialization script for Wheels Docker setup
 
 -- Create a user for the application
 CREATE USER cfwheels WITH PASSWORD 'cfwheels';
@@ -272,7 +272,7 @@ CREATE DATABASE cfwheels OWNER cfwheels;
     private void function createMsSqlInit(required string path) {
         local.initSqlPath = arguments.path & "/init.sql";
         
-        local.initSqlContent = "-- SQL Server initialization script for CFWheels Docker setup
+        local.initSqlContent = "-- SQL Server initialization script for Wheels Docker setup
 
 -- Create the database
 IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'cfwheels')
@@ -311,7 +311,7 @@ GO
     private void function createDockerIgnore() {
         local.dockerIgnorePath = fileSystemUtil.resolvePath(".dockerignore");
         
-        local.dockerIgnoreContent = "# .dockerignore for CFWheels application
+        local.dockerIgnoreContent = "# .dockerignore for Wheels application
 
 # Version control
 .git

--- a/commands/wheels/generate/api-resource.cfc
+++ b/commands/wheels/generate/api-resource.cfc
@@ -22,7 +22,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels API Resource Generator");
+        print.boldMagentaLine("Wheels API Resource Generator");
         print.line();
         
         // Process resource name

--- a/commands/wheels/generate/app-wizard.cfc
+++ b/commands/wheels/generate/app-wizard.cfc
@@ -1,5 +1,5 @@
 /**
- * Creates a new CFWheels application using our wizard to gather all the 
+ * Creates a new Wheels application using our wizard to gather all the 
  * necessary information. This is the recommended route to start a new application.
  *
  * This command will ask for:
@@ -40,9 +40,9 @@ component aliases="wheels g app-wizard, wheels new" extends="../base" {
 
     // ---------------- Welcome
     print.greenBoldLine( '========= Hello! Welcome to the Wizard ===========' )
-      .greenBoldLine( '| Welcome to the CFWheels app wizard. We''re here |' )
+      .greenBoldLine( '| Welcome to the Wheels app wizard. We''re here |' )
       .greenBoldLine( '| to try and give you a helping hand to start yo |' )
-      .greenBoldLine( '| CFWheels app.                                  |' )
+      .greenBoldLine( '| Wheels app.                                  |' )
       .greenBoldLine( '==================================================' )
       .line()
       .toConsole();
@@ -52,14 +52,14 @@ component aliases="wheels g app-wizard, wheels new" extends="../base" {
     print.greenBoldLine( '========= We Need Some Information ===============' )
       .greenBoldLine( '| To get going, we''re going to need to know a    |' )
       .greenBoldLine( '| NAME for your application. We''ll start with    |' )
-      .greenBoldLine( '| a name like MyCFWheelsApp. Keep in  mind       |' )
+      .greenBoldLine( '| a name like MyWheelsApp. Keep in  mind       |' )
       .greenBoldLine( '| that a new directory will be created for your  |' )
       .greenBoldLine( '| app in your current working directory.         |' )
       .greenBoldLine( '==================================================' )
       .line()
       .toConsole();
 
-    var appName = ask( message = 'Please enter a name for your application: ', defaultResponse = 'MyCFWheelsApp' );
+    var appName = ask( message = 'Please enter a name for your application: ', defaultResponse = 'MyWheelsApp' );
     appName     = helpers.stripSpecialChars( appName );
     print.line().toConsole();
 
@@ -77,9 +77,9 @@ component aliases="wheels g app-wizard, wheels new" extends="../base" {
       .options( [
         {value: 'cfwheels-base-template', display: '2.5.x - Wheels Base Template - Stable Release', selected: true},
         {value: 'wheels-base-template@BE', display: '3.0.x - Wheels Base Template - Bleeding Edge'},
-        {value: 'cfwheels-template-htmx-alpine-simple', display: 'CFWheels Template - HTMX - Alpine.js - Simple.css'},
-        {value: 'cfwheels-template-example-app', display: 'CFWheels Example App'},
-        {value: 'cfwheels-todomvc-htmx', display: 'CFWheels - TodoMVC - HTMX - Demo App'},
+        {value: 'cfwheels-template-htmx-alpine-simple', display: 'Wheels Template - HTMX - Alpine.js - Simple.css'},
+        {value: 'cfwheels-template-example-app', display: 'Wheels Example App'},
+        {value: 'cfwheels-todomvc-htmx', display: 'Wheels - TodoMVC - HTMX - Demo App'},
         {value: 'custom', display: 'Enter a custom template endpoint'}
       ] )
       .required()

--- a/commands/wheels/generate/app.cfc
+++ b/commands/wheels/generate/app.cfc
@@ -1,7 +1,7 @@
 /**
- *  Create a blank CFWheels app from one of our app templates or a template using a valid Endpoint ID which can come from .
+ *  Create a blank Wheels app from one of our app templates or a template using a valid Endpoint ID which can come from .
  *  ForgeBox, HTTP/S, git, github, etc.
- *  By default an app named MyCFWheelsApp will be created in a sub directoryt call MyCFWheelsApp.
+ *  By default an app named MyWheelsApp will be created in a sub directoryt call MyWheelsApp.
  *
  *  The most basic call...
  *  {code:bash}
@@ -21,11 +21,11 @@
  *  Here are the basic templates that are available for you that come from ForgeBox
  *  - Wheels Base Template - Stable (default)
  *  - Wheels Base Template - Bleeding Edge
- *  - CFWheels Template - HelloWorld
- *  - CFWheels Template - HelloDynamic
- *  - CFWheels Template - HelloPages
- *  - CFWheels Example App
- *  - CFWheels - TodoMVC - HTMX - Demp App
+ *  - Wheels Template - HelloWorld
+ *  - Wheels Template - HelloDynamic
+ *  - Wheels Template - HelloPages
+ *  - Wheels Example App
+ *  - Wheels - TodoMVC - HTMX - Demp App
  *
  * {code:bash}
  * wheels create app template=base
@@ -68,7 +68,7 @@ component aliases="wheels g app" extends="../base" {
    * @force          Force installation into an none empty directory
    **/
   function run(
-    name     = 'MyCFWheelsApp',
+    name     = 'MyWheelsApp',
     template = 'Base',
     directory,
     reloadPassword = 'changeMe',

--- a/commands/wheels/generate/frontend.cfc
+++ b/commands/wheels/generate/frontend.cfc
@@ -1,5 +1,5 @@
 /**
- * Scaffold and integrate modern frontend frameworks with CFWheels
+ * Scaffold and integrate modern frontend frameworks with Wheels
  * 
  * {code:bash}
  * wheels generate frontend --framework=react
@@ -21,7 +21,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Frontend Generator");
+        print.boldMagentaLine("Wheels Frontend Generator");
         print.line();
         
         // Validate framework selection
@@ -80,7 +80,7 @@ component extends="../base" {
         local.packageJson = {
             "name": "cfwheels-frontend",
             "version": "1.0.0",
-            "description": "Frontend for CFWheels application",
+            "description": "Frontend for Wheels application",
             "scripts": {
                 "dev": "vite",
                 "build": "vite build",
@@ -143,7 +143,7 @@ function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <h1>CFWheels + React</h1>
+        <h1>Wheels + React</h1>
         <p>
           <button onClick={() => setCount((count) => count + 1)}>
             count is {count}
@@ -235,7 +235,7 @@ const count = ref(0);
 <template>
   <div class="app">
     <header class="app-header">
-      <h1>CFWheels + Vue</h1>
+      <h1>Wheels + Vue</h1>
       <p>
         <button type="button" @click="count++">count is {{ count }}</button>
       </p>
@@ -325,12 +325,12 @@ Alpine.start();';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CFWheels + Alpine.js</title>
+    <title>Wheels + Alpine.js</title>
   </head>
   <body>
     <div id="app" x-data="{ count: 0 }">
       <header class="app-header">
-        <h1>CFWheels + Alpine.js</h1>
+        <h1>Wheels + Alpine.js</h1>
         <p>
           <button type="button" x-on:click="count++">
             count is <span x-text="count"></span>
@@ -470,7 +470,7 @@ function frontendAssets() {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CFWheels with #arguments.framework#</title>
+    <title>Wheels with #arguments.framework#</title>
     #frontendAssets()#
 </head>
 <body>

--- a/commands/wheels/info.cfc
+++ b/commands/wheels/info.cfc
@@ -22,10 +22,10 @@ component  extends="base"  {
 			.redLine("|  |    |  `--, |  |.'.|  ||  .-.  || .-. :| .-. :|  |(  .-'     |  |    |  |   |  | ")
 			.redLine("'  '--'\|  |`   |   ,'.   ||  | |  |\   --.\   --.|  |.-'  `)    '  '--'\|  '--.|  | ")
 			.redLine(" `-----'`--'    '--'   '--'`--' `--' `----' `----'`--'`----'      `-----'`-----'`--' ")
-			.yellowBoldLine( "=================================== CFWheels CLI ===================================" )
+			.yellowBoldLine( "=================================== Wheels CLI ===================================" )
 			.yellowBoldLine( "Current Working Directory: #current.directory#")
 			.yellowBoldLine( "CommandBox Module Root: #current.moduleRoot#")
-			.yellowBoldLine( "Current CFWheels Version in this directory: #current.wheelsVersion#")
+			.yellowBoldLine( "Current Wheels Version in this directory: #current.wheelsVersion#")
 			.yellowBoldLine( "====================================================================================" );
 	}
 

--- a/commands/wheels/init.cfc
+++ b/commands/wheels/init.cfc
@@ -19,7 +19,7 @@ component  extends="base"  {
 
 		print.greenBoldLine( "==================================== Wheels init ===================================" )
 			   .greenBoldLine( " This function will attempt to add a few things " )
-				 .greenBoldLine( " to an EXISTING CFWheels installation to help   " )
+				 .greenBoldLine( " to an EXISTING Wheels installation to help   " )
 				 .greenBoldLine( " the CLI interact." )
 				 .greenBoldLine( " " )
 				 .greenBoldLine( " We're going to assume the following:" )

--- a/commands/wheels/plugins/list.cfc
+++ b/commands/wheels/plugins/list.cfc
@@ -1,5 +1,5 @@
 /**
- * Shows Forgebox Plugins List for CFWheels
+ * Shows Forgebox Plugins List for Wheels
  *
  * {code:bash}
  * wheels plugins list
@@ -11,7 +11,7 @@ component aliases="wheels plugin list" extends="../base"  {
 	 *
 	 **/
 	function run(  ) {
-		print.greenBoldLine("================ CFWheels Plugins From Forgebox ======================")
+		print.greenBoldLine("================ Wheels Plugins From Forgebox ======================")
 		command('forgebox show').params(type="cfwheels-plugins").run();
 		print.greenBoldLine("======================================================================");
 	}

--- a/commands/wheels/test/coverage.cfc
+++ b/commands/wheels/test/coverage.cfc
@@ -26,7 +26,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Test Coverage");
+        print.boldMagentaLine("Wheels Test Coverage");
         print.line();
         
         // Set target directory for report

--- a/commands/wheels/test/debug.cfc
+++ b/commands/wheels/test/debug.cfc
@@ -27,7 +27,7 @@ component extends="../base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine("CFWheels Test Debug Mode");
+        print.boldMagentaLine("Wheels Test Debug Mode");
         print.line();
         
         // Format URL parameters

--- a/commands/wheels/watch.cfc
+++ b/commands/wheels/watch.cfc
@@ -1,5 +1,5 @@
 /**
- * Watch CFWheels application files for changes and automatically reload the application.
+ * Watch Wheels application files for changes and automatically reload the application.
  * 
  * {code:bash}
  * wheels watch
@@ -21,7 +21,7 @@ component extends="base" {
     ) {
         // Welcome message
         print.line();
-        print.boldMagentaLine( "CFWheels Watch Mode" );
+        print.boldMagentaLine( "Wheels Watch Mode" );
         print.line( "Monitoring files for changes..." );
         print.line( "Press Ctrl+C to stop watching" );
         print.line();

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# CFWheels CLI Documentation
+# Wheels CLI Documentation
 
-The CFWheels CLI is a CommandBox module that provides command-line tools for CFWheels framework applications. This documentation covers all available commands and their usage.
+The Wheels CLI is a CommandBox module that provides command-line tools for Wheels framework applications. This documentation covers all available commands and their usage.
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@ The CFWheels CLI is a CommandBox module that provides command-line tools for CFW
 
 ## Installation
 
-Install the CFWheels CLI as a CommandBox module:
+Install the Wheels CLI as a CommandBox module:
 
 ```bash
 box install wheels-cli
@@ -28,13 +28,13 @@ box install wheels-cli
 
 ## Getting Started
 
-To create a new CFWheels application:
+To create a new Wheels application:
 
 ```bash
 wheels init myApp
 ```
 
-This will create a new CFWheels application in the "myApp" directory.
+This will create a new Wheels application in the "myApp" directory.
 
 ## Command Reference
 
@@ -42,7 +42,7 @@ This will create a new CFWheels application in the "myApp" directory.
 
 #### Init
 
-Creates a new CFWheels application.
+Creates a new Wheels application.
 
 ```bash
 wheels init [name] [path] [reload] [version] [createFolders]
@@ -52,12 +52,12 @@ wheels init [name] [path] [reload] [version] [createFolders]
 - `name`: Name of the application
 - `path`: Path for the new application
 - `reload`: Force a reload of the application
-- `version`: CFWheels version to use
+- `version`: Wheels version to use
 - `createFolders`: Create standard folders structure
 
 #### Reload
 
-Reloads the CFWheels application.
+Reloads the Wheels application.
 
 ```bash
 wheels reload
@@ -65,7 +65,7 @@ wheels reload
 
 #### Info
 
-Displays information about the CFWheels application.
+Displays information about the Wheels application.
 
 ```bash
 wheels info
@@ -154,7 +154,7 @@ wheels generate api-resource [name] [--model=false] [--docs=false] [--auth=false
 
 #### Generate Frontend
 
-Scaffold and integrate modern frontend frameworks with CFWheels.
+Scaffold and integrate modern frontend frameworks with Wheels.
 
 ```bash
 wheels generate frontend --framework=[framework] [--path=app/assets/frontend] [--api=false]
@@ -421,7 +421,7 @@ wheels analyze [--target=all] [--duration=60] [--report=true] [--threshold=5]
 
 #### Dependencies
 
-Manage CFWheels-specific dependencies and plugins.
+Manage Wheels-specific dependencies and plugins.
 
 ```bash
 wheels deps [action] [name] [version]

--- a/docs/application-management.md
+++ b/docs/application-management.md
@@ -1,10 +1,10 @@
 # Application Management Commands
 
-The CFWheels CLI provides several commands for managing your application's lifecycle.
+The Wheels CLI provides several commands for managing your application's lifecycle.
 
 ## Init
 
-Creates a new CFWheels application.
+Creates a new Wheels application.
 
 ### Usage
 
@@ -17,7 +17,7 @@ wheels init [name] [path] [reload] [version] [createFolders]
 - `name`: Name of the application (default: cfwheels)
 - `path`: Path for the new application (default: current directory)
 - `reload`: Force a reload of the application (default: false)
-- `version`: CFWheels version to use (default: latest)
+- `version`: Wheels version to use (default: latest)
 - `createFolders`: Create standard folders structure (default: true)
 
 ### Examples
@@ -35,7 +35,7 @@ wheels init myApp path=/path/to/apps
 
 ## Reload
 
-Reloads the CFWheels application, which is useful during development after making changes to the codebase.
+Reloads the Wheels application, which is useful during development after making changes to the codebase.
 
 ### Usage
 
@@ -52,7 +52,7 @@ wheels reload
 
 ## Info
 
-Displays information about the CFWheels application, including the version, environment, database configuration, and plugins.
+Displays information about the Wheels application, including the version, environment, database configuration, and plugins.
 
 ### Usage
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,10 @@
 # Configuration Management Commands
 
-The CFWheels CLI provides tools to manage your application's configuration across different environments.
+The Wheels CLI provides tools to manage your application's configuration across different environments.
 
 ## Config List
 
-List all configuration settings for your CFWheels application.
+List all configuration settings for your Wheels application.
 
 ### Usage
 
@@ -36,7 +36,7 @@ wheels config:list --showSensitive=true
 
 ## Config Set
 
-Set configuration values for your CFWheels application.
+Set configuration values for your Wheels application.
 
 ### Usage
 
@@ -65,7 +65,7 @@ wheels config:set apiKey=1234567890 --encrypt=true
 
 ## Config Environment
 
-Manage environment-specific settings for your CFWheels application.
+Manage environment-specific settings for your Wheels application.
 
 ### Usage
 
@@ -115,7 +115,7 @@ wheels config:env copy development staging
 
 ## Configuration Files
 
-CFWheels uses several configuration files that can be managed through these commands:
+Wheels uses several configuration files that can be managed through these commands:
 
 - **config/settings.cfm**: Main application settings
 - **config/environment.cfm**: Environment detection and configuration
@@ -126,7 +126,7 @@ The configuration commands help manage these files without having to edit them d
 
 ## Working with Multiple Environments
 
-The CFWheels CLI configuration commands make it easy to manage configurations across different environments:
+The Wheels CLI configuration commands make it easy to manage configurations across different environments:
 
 ```bash
 # Setting up a new environment

--- a/docs/database-commands.md
+++ b/docs/database-commands.md
@@ -1,6 +1,6 @@
 # Database Commands
 
-The CFWheels CLI includes comprehensive database management commands, including migrations, seeding, and schema visualization.
+The Wheels CLI includes comprehensive database management commands, including migrations, seeding, and schema visualization.
 
 ## DBMigrate Commands
 

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,10 +1,10 @@
 # Dependency Management Commands
 
-The CFWheels CLI provides commands to manage CFWheels-specific dependencies and plugins, ensuring compatibility and proper versioning.
+The Wheels CLI provides commands to manage Wheels-specific dependencies and plugins, ensuring compatibility and proper versioning.
 
 ## Dependencies Command
 
-Manage CFWheels-specific dependencies and plugins with version control.
+Manage Wheels-specific dependencies and plugins with version control.
 
 ### Usage
 
@@ -108,7 +108,7 @@ wheels deps report
 This command produces a report containing:
 - List of installed plugins with versions
 - Dependencies between plugins
-- Compatibility status with your CFWheels version
+- Compatibility status with your Wheels version
 - Potential conflicts or issues
 
 ## Dependency Report
@@ -190,7 +190,7 @@ When you encounter plugin conflicts:
 
 ## Extending the Dependency System
 
-The CFWheels dependency system can be extended to handle:
+The Wheels dependency system can be extended to handle:
 
 ### Custom Repositories
 

--- a/docs/development-tools.md
+++ b/docs/development-tools.md
@@ -1,6 +1,6 @@
 # Development Tools
 
-The CFWheels CLI provides a comprehensive set of tools to speed up the development process by generating code for common components.
+The Wheels CLI provides a comprehensive set of tools to speed up the development process by generating code for common components.
 
 ## Generate Controller
 
@@ -135,7 +135,7 @@ wheels generate api-resource products --auth=true
 
 ## Generate Frontend
 
-Scaffold and integrate modern frontend frameworks with CFWheels.
+Scaffold and integrate modern frontend frameworks with Wheels.
 
 ### Usage
 
@@ -221,5 +221,5 @@ The frontend integration provides:
 1. Project structure for the selected framework
 2. Package.json with appropriate dependencies
 3. Vite build configuration
-4. Integration helpers for including the frontend in CFWheels views
+4. Integration helpers for including the frontend in Wheels views
 5. Sample application structure

--- a/docs/devops.md
+++ b/docs/devops.md
@@ -1,6 +1,6 @@
 # DevOps Commands
 
-The CFWheels CLI includes commands to streamline DevOps processes, including CI/CD configuration and Docker containerization.
+The Wheels CLI includes commands to streamline DevOps processes, including CI/CD configuration and Docker containerization.
 
 ## CI/CD Configuration
 

--- a/docs/frontend-and-api.md
+++ b/docs/frontend-and-api.md
@@ -1,14 +1,14 @@
 # Frontend and API Development Commands
 
-The CFWheels CLI provides commands to help integrate modern frontend frameworks and build API endpoints in your application.
+The Wheels CLI provides commands to help integrate modern frontend frameworks and build API endpoints in your application.
 
 ## Frontend Integration
 
-Modern web applications often use JavaScript frontend frameworks. The CFWheels CLI provides tools to scaffold and integrate popular frontend frameworks with your CFWheels application.
+Modern web applications often use JavaScript frontend frameworks. The Wheels CLI provides tools to scaffold and integrate popular frontend frameworks with your Wheels application.
 
 ### Generate Frontend
 
-Scaffold and integrate modern frontend frameworks with CFWheels.
+Scaffold and integrate modern frontend frameworks with Wheels.
 
 #### Usage
 
@@ -42,7 +42,7 @@ The frontend generator creates:
 1. **Project Structure**: Directory structure for the selected framework
 2. **Dependencies**: package.json with appropriate dependencies
 3. **Build Configuration**: Vite configuration for modern build process
-4. **Asset Pipeline**: Integration helpers for including built assets in CFWheels views
+4. **Asset Pipeline**: Integration helpers for including built assets in Wheels views
 5. **Example Components**: Sample components to help you get started
 6. **Optional API**: API endpoints if the `--api` flag is enabled
 
@@ -76,7 +76,7 @@ When selecting Alpine.js, the generator creates:
 
 ## API Development
 
-Modern applications often need to expose data via APIs. The CFWheels CLI provides tools to build RESTful API endpoints.
+Modern applications often need to expose data via APIs. The Wheels CLI provides tools to build RESTful API endpoints.
 
 ### Generate API Resource
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# CFWheels CLI Documentation
+# Wheels CLI Documentation
 
-Welcome to the comprehensive documentation for the CFWheels CLI, a command-line tool that enhances your development experience when working with the CFWheels framework.
+Welcome to the comprehensive documentation for the Wheels CLI, a command-line tool that enhances your development experience when working with the Wheels framework.
 
 ## Documentation Sections
 
@@ -17,13 +17,13 @@ Welcome to the comprehensive documentation for the CFWheels CLI, a command-line 
 
 ## Quick Start
 
-Install the CFWheels CLI:
+Install the Wheels CLI:
 
 ```bash
 box install wheels-cli
 ```
 
-Create a new CFWheels application:
+Create a new Wheels application:
 
 ```bash
 wheels init myApp

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,10 +1,10 @@
 # Performance Analysis Commands
 
-The CFWheels CLI provides tools to analyze and optimize the performance of your application.
+The Wheels CLI provides tools to analyze and optimize the performance of your application.
 
 ## Analyze
 
-Identify performance bottlenecks in your CFWheels application.
+Identify performance bottlenecks in your Wheels application.
 
 ### Usage
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing Commands
 
-The CFWheels CLI provides robust tools for testing your application, including running tests, generating code coverage reports, and debugging test failures.
+The Wheels CLI provides robust tools for testing your application, including running tests, generating code coverage reports, and debugging test failures.
 
 ## Test
 

--- a/templates/BoxJSON.txt
+++ b/templates/BoxJSON.txt
@@ -1,21 +1,21 @@
 {
     "name":"|appName|",
     "version":"1.0.0",
-    "author":"CFWheels Core Team and Community, repackaged by Peter Amiri",
-    "shortDescription":"CFWheels MVC Framework Base Template",
+    "author":"Wheels Core Team and Community, repackaged by Peter Amiri",
+    "shortDescription":"Wheels MVC Framework Base Template",
     "location":"",
     "slug":"myapp",
     "createPackageDirectory":false,
-    "type":"cfwheels-templates",
+    "type":"wheels-templates",
     "keywords":[
         "mvc",
         "rails",
         "wheels",
-        "cfwheels",
+        "wheels",
         "core"
     ],
-    "homepage":"https://cfwheels.org/",
-    "documentation":"https://docs.cfwheels.org/",
+    "homepage":"https://wheels.dev/",
+    "documentation":"https://docs.wheels.dev/",
     "repository":{
         "type":"git",
         "URL":"https://github.com/cfwheels/cfwheels"
@@ -31,10 +31,10 @@
         "commandbox-cfformat":"*"
     },
     "installPaths":{
-        "cfwheels":"wheels/"
+        "wheels":"wheels/"
     },
     "dependencies":{
-        "cfwheels":"|version|",
+        "wheels":"|version|",
         "orgh213172lex":"lex:https://ext.lucee.org/org.h2-1.3.172.lex"
     },
     "private":false,

--- a/templates/ConfigAppContent.txt
+++ b/templates/ConfigAppContent.txt
@@ -7,7 +7,7 @@
 		this.sessionTimeout = CreateTimeSpan(0,0,5,0);
 	*/
 
-	// Added via CFWheels CLI
+	// Added via Wheels CLI
 	this.name = "|appName|";
 	// CLI-Appends-Here
 </cfscript>

--- a/templates/ConfigDataSourceH2Content.txt
+++ b/templates/ConfigDataSourceH2Content.txt
@@ -1,6 +1,6 @@
 <cfscript>
 	/*
-		If you leave these settings commented out, CFWheels will set the data source name to the same name as the folder the application resides in.
+		If you leave these settings commented out, Wheels will set the data source name to the same name as the folder the application resides in.
 	*/
 
 	// set(dataSourceName="");
@@ -8,13 +8,13 @@
 	// set(dataSourcePassword="");
 
 	/*
-		If you leave this setting commented out, CFWheels will try to determine the URL rewrite capabilities automatically.
+		If you leave this setting commented out, Wheels will try to determine the URL rewrite capabilities automatically.
 		The "URLRewriting" setting can bet set to "on", "partial" or "off".
 		To run with "partial" rewriting, the "cgi.path_info" variable needs to be supported by the web server.
 		To run with rewriting set to "on", you need to apply the necessary rewrite rules on the web server first.
 	*/
 
-	// Added via CFWheels CLI
+	// Added via Wheels CLI
 	set(dataSourceName="|datasourceName|");
 	set(URLRewriting="On");
 	// Reload your application with ?reload=true&password=|reloadPassword|

--- a/templates/ConfigReloadPasswordContent.txt
+++ b/templates/ConfigReloadPasswordContent.txt
@@ -1,6 +1,6 @@
 <cfscript>
 	/*
-		If you leave these settings commented out, CFWheels will set the data source name to the same name as the folder the application resides in.
+		If you leave these settings commented out, Wheels will set the data source name to the same name as the folder the application resides in.
 	*/
 
 	// set(dataSourceName="");
@@ -8,13 +8,13 @@
 	// set(dataSourcePassword="");
 
 	/*
-		If you leave this setting commented out, CFWheels will try to determine the URL rewrite capabilities automatically.
+		If you leave this setting commented out, Wheels will try to determine the URL rewrite capabilities automatically.
 		The "URLRewriting" setting can bet set to "on", "partial" or "off".
 		To run with "partial" rewriting, the "cgi.path_info" variable needs to be supported by the web server.
 		To run with rewriting set to "on", you need to apply the necessary rewrite rules on the web server first.
 	*/
 
-	// Added via CFWheels CLI
+	// Added via Wheels CLI
 	set(dataSourceName="|datasourceName|");
 	set(URLRewriting="On");
 	// Reload your application with ?reload=true&password=|reloadPassword|

--- a/templates/ConfigRoutes.txt
+++ b/templates/ConfigRoutes.txt
@@ -2,7 +2,7 @@
 
 	// Use this file to add routes to your application and point the root route to a controller action.
 	// Don't forget to issue a reload request (e.g. reload=true) after making changes.
-	// See https://guides.cfwheels.org/docs/routing for more info.
+	// See https://guides.wheels.dev/docs/routing for more info.
 
 	mapper()
 		// CLI-Appends-Here

--- a/templates/WheelsBoxJSON.txt
+++ b/templates/WheelsBoxJSON.txt
@@ -1,5 +1,5 @@
 {
     "VERSION":"|version|",
-    "SLUG":"cfwheels",
+    "SLUG":"wheels",
     "TYPE":"mvc"
 }


### PR DESCRIPTION
## Summary
- Updated all references from CFWheels to Wheels across the entire codebase
- Changed domain references from cfwheels.org to wheels.dev
- Updated documentation to use consistent branding
- Modified template files and configuration examples
- Maintained all functionality while updating the naming convention

## Details
This PR implements a consistent naming strategy across the codebase, changing all references from CFWheels to simply Wheels. This affects documentation, command descriptions, and templates.

## Test plan
- All commands function the same, just with updated naming in outputs
- Documentation references have been updated for consistency
- Template files contain the new naming convention